### PR TITLE
#12 allow defining specific percentages for rarity/layer combinations...

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To ensure uniqueness, we want to add various features and multiple options for e
 To start, copy the layers/features and their images in a flat hierarchy at a directory of your choice (by default we expect them in `./input/`). The features should contain options for each rarity that is provided via the config file.
 
 After adding the `layers`, adjust them accordingly in the `config.js` by providing the directory path, positioning and sizes.
+Use the existing `addLayers` calls as guidance for how to add layers. This can either only use the name of the layer and will use default positioning (x=0, y=0) and sizes (width=configured width, height=configure height), or positioning and sizes can be provided for more flexibility.
 
 ### Allowing different rarities for certain rarity/layer combinations
 It is possible to provide a percentage at which e.g. a rare item would contain a rare vs. common part in a given layer. This can be done via the `addRarityPercentForLayer` that can be found in the `config.js` as well. 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The file `./input/config.js` contains the following properties that can be adjus
 - baseImageUri: - URL base to access your NFTs from. This will be used by platforms to find your image resource. This expects the image to be accessible by it's id like `${baseImageUri}/${id}`.
 - startEditionFrom: - number (int) to start naming NFTs from. Default: `1`
 - editionSize: - number (int) to end edition at. Default: `10`
+- editionDnaPrefix: - value (number or string) that indicates which dna from an edition is used there. I.e. dna `0` from to independent batches in the same edition may differ, and can be differentiated using this. Default: `0`
 - rarityWeights: - allows to provide rarity categories and how many of each type to include in an edition. Default: `1 super_rare, 4 rare, 5 original`
 - layers: list of layers that should be used to render the image. See next section for detail.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Create generative art by using the canvas api and node js, feel free to contribu
 # How to use
 ## Run the code
 1. Run `node index.js`
-2. Open the `./output` folder to find your generated images to use as NFTs
+2. Open the `./output` folder to find your generated images to use as NFTs, as well as the metadata to use for NFT marketplaces.
 
 ## Adjust the provided configuration and resources
 ### Configuration file
@@ -17,20 +17,20 @@ The file `./input/config.js` contains the following properties that can be adjus
 - width: - of your image in pixels. Default: `1000px`
 - height: - of your image in pixels. Default: `1000px`
 - dir: - where image parts are stored. Default: `./input`
-- description: - of your generated NFT
+- description: - of your generated NFT. Default: `This is an NFT made by the coolest generative code.`
 - baseImageUri: - URL base to access your NFTs from. This will be used by platforms to find your image resource. This expects the image to be accessible by it's id like `${baseImageUri}/${id}`.
-- startEditionFrom: - number (int) to start naming NFTs from.
-- editionSize: - number (int) to end edition at.
-- rarityWeights: - allows to provide rarity categories and how many of each type to include in an edition.
+- startEditionFrom: - number (int) to start naming NFTs from. Default: `1`
+- editionSize: - number (int) to end edition at. Default: `10`
+- rarityWeights: - allows to provide rarity categories and how many of each type to include in an edition. Default: `1 super_rare, 4 rare, 5 original`
 - layers: list of layers that should be used to render the image. See next section for detail.
 
 ### Image layers 
-The image layers are different parts that make up a full image by overlaying on top of each other. E.g. in this example we start with the eyeball and layer features like the eye lids or iris on top to create the completed and unique eye, which we can then use as part of our NFT collection.
+The image layers are different parts that make up a full image by overlaying on top of each other. E.g. in the example input content of this repository we start with the eyeball and layer features like the eye lids or iris on top to create the completed and unique eye, which we can then use as part of our NFT collection.
 To ensure uniqueness, we want to add various features and multiple options for each of them in order to allow enough permutations for the amount of unique images we require.
 
 To start, copy the layers/features and their images in a flat hierarchy at a directory of your choice (by default we expect them in `./input/`). The features should contain options for each rarity that is provided via the config file.
 
-After adding the layers, adjust them accordingly in the `config.js` by providing the directory path, positioning and sizes.
+After adding the `layers`, adjust them accordingly in the `config.js` by providing the directory path, positioning and sizes.
 
 # Development suggestions
 - Preferably use VSCode with the prettifier plugin for a consistent coding style (or equivalent js formatting rules)

--- a/README.md
+++ b/README.md
@@ -32,5 +32,9 @@ To start, copy the layers/features and their images in a flat hierarchy at a dir
 
 After adding the `layers`, adjust them accordingly in the `config.js` by providing the directory path, positioning and sizes.
 
+### Allowing different rarities for certain rarity/layer combinations
+It is possible to provide a percentage at which e.g. a rare item would contain a rare vs. common part in a given layer. This can be done via the `addRarityPercentForLayer` that can be found in the `config.js` as well. 
+This allows for more fine grained control over how much randomness there should be during the generation process, and allows a combination of common and rare parts.
+
 # Development suggestions
 - Preferably use VSCode with the prettifier plugin for a consistent coding style (or equivalent js formatting rules)

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ const drawElement = (_element) => {
 // drawing on a canvas
 const constructLayerToDna = (_dna = [], _layers = [], _rarity) => {
   let mappedDnaToLayers = _layers.map((layer, index) => {
-    let selectedElement = layer.elements[_rarity][_dna[index]];
+    let selectedElement = layer.elements.find(element => element.id === _dna[index]);
     return {
       location: layer.location,
       position: layer.position,
@@ -100,7 +100,6 @@ const constructLayerToDna = (_dna = [], _layers = [], _rarity) => {
       selectedElement: selectedElement,
     };
   });
-
   return mappedDnaToLayers;
 };
 
@@ -111,13 +110,35 @@ const isDnaUnique = (_DnaList = [], _dna = []) => {
   return foundDna == undefined ? true : false;
 };
 
+const getRandomRarity = (_rarityOptions) => {
+  let randomPercent = Math.random() * 100;
+  let percentCount = 0;
+
+  for (let i = 0; i <= _rarityOptions.length; i++) {
+    percentCount += _rarityOptions[i].percent;
+    if (percentCount >= randomPercent) {
+      console.log(`use random rarity ${_rarityOptions[i].id}`)
+      return _rarityOptions[i].id;
+    }
+  }
+  return _rarityOptions[0].id;
+}
+
 // create a dna based on the available layers for the given rarity
 // use a random part for each layer
 const createDna = (_layers, _rarity) => {
   let randNum = [];
+  let _rarityWeight = rarityWeights.find(rw => rw.value === _rarity);
   _layers.forEach((layer) => {
-    let num = Math.floor(Math.random() * layer.elements[_rarity].length);
-    randNum.push(num);
+    let num = Math.floor(Math.random() * layer.elementIdsForRarity[_rarity].length);
+    if (_rarityWeight && _rarityWeight.layerPercent[layer.id]) {
+      // if there is a layerPercent defined, we want to identify which dna to actually use here (instead of only picking from the same rarity)
+      let _rarityForLayer = getRandomRarity(_rarityWeight.layerPercent[layer.id]);
+      num = Math.floor(Math.random() * layer.elementIdsForRarity[_rarityForLayer].length);
+      randNum.push(layer.elementIdsForRarity[_rarityForLayer][num]);
+    } else {
+      randNum.push(layer.elementIdsForRarity[_rarity][num]);
+    }
   });
   return randNum;
 };

--- a/input/config.js
+++ b/input/config.js
@@ -1,102 +1,160 @@
+/**************************************************************
+ * UTILITY FUNCTIONS
+ * - scroll to BEGIN CONFIG to provide the config values
+ *************************************************************/
 const fs = require("fs");
-const width = 1000;
-const height = 1000;
 const dir = __dirname;
-const description = "This is an NFT made by the coolest generative code.";
-const baseImageUri = "https://hashlips/nft";
-const startEditionFrom = 1;
-const editionSize = 10;
-const rarityWeights = [
-  {
-    value: "super_rare",
-    from: 1,
-    to: 1,
-  },
-  {
-    value: "rare",
-    from: 2,
-    to: 5,
-  },
-  {
-    value: "original",
-    from: 5,
-    to: editionSize,
-  },
-];
 
+// adds a rarity to the configuration. This is expected to correspond with a directory containing the rarity for each defined layer
+// @param _id - id of the rarity
+// @param _from - number in the edition to start this rarity from
+// @param _to - number in the edition to generate this rarity to
+// @return a rarity object used to dynamically generate the NFTs
+const addRarity = (_id, _from, _to) => {
+  const _rarityWeight = {
+    value: _id,
+    from: _from,
+    to: _to,
+    layerPercent: {}
+  };
+  return _rarityWeight;
+};
+
+// get the name without last 4 characters -> slice .png from the name
 const cleanName = (_str) => {
   let name = _str.slice(0, -4);
   return name;
 };
 
-const getElements = (path) => {
+// reads the filenames of a given folder and returns it with its name and path
+const getElements = (_path, _elementCount) => {
   return fs
-    .readdirSync(path)
+    .readdirSync(_path)
     .filter((item) => !/(^|\/)\.[^\/\.]/g.test(item))
     .map((i) => {
       return {
+        id: _elementCount,
         name: cleanName(i),
-        path: `${path}/${i}`,
+        path: `${_path}/${i}`
       };
     });
 };
 
-const layers = [
-  {
-    elements: {
-      original: getElements(`${dir}/ball/original`),
-      rare: getElements(`${dir}/ball/rare`),
-      super_rare: getElements(`${dir}/ball/super_rare`),
-    },
-    position: { x: 0, y: 0 },
-    size: { width: width, height: height },
-  },
-  {
-    elements: {
-      original: getElements(`${dir}/eye color/original`),
-      rare: getElements(`${dir}/eye color/rare`),
-      super_rare: getElements(`${dir}/eye color/super_rare`),
-    },
-    position: { x: 0, y: 0 },
-    size: { width: width, height: height },
-  },
-  {
-    elements: {
-      original: getElements(`${dir}/iris/original`),
-      rare: getElements(`${dir}/iris/rare`),
-      super_rare: getElements(`${dir}/iris/super_rare`),
-    },
-    position: { x: 0, y: 0 },
-    size: { width: width, height: height },
-  },
-  {
-    elements: {
-      original: getElements(`${dir}/shine/original`),
-      rare: getElements(`${dir}/shine/rare`),
-      super_rare: getElements(`${dir}/shine/super_rare`),
-    },
-    position: { x: 0, y: 0 },
-    size: { width: width, height: height },
-  },
-  {
-    elements: {
-      original: getElements(`${dir}/bottom lid/original`),
-      rare: getElements(`${dir}/bottom lid/rare`),
-      super_rare: getElements(`${dir}/bottom lid/super_rare`),
-    },
-    position: { x: 0, y: 0 },
-    size: { width: width, height: height },
-  },
-  {
-    elements: {
-      original: getElements(`${dir}/top lid/original`),
-      rare: getElements(`${dir}/top lid/rare`),
-      super_rare: getElements(`${dir}/top lid/super_rare`),
-    },
-    position: { x: 0, y: 0 },
-    size: { width: width, height: height },
-  },
+// adds a layer to the configuration. The layer will hold information on all the defined parts and 
+// where they should be rendered in the image
+// @param _id - id of the layer
+// @param _position - on which x/y value to render this part
+// @param _size - of the image
+// @return a layer object used to dynamically generate the NFTs
+const addLayer = (_id, _position, _size) => {
+  if (!_id) {
+    console.log('error adding layer, parameters id required');
+    return null;
+  }
+  if (!_position) {
+    _position = { x: 0, y: 0 };
+  }
+  if (!_size) {
+    _size = { width: width, height: height }
+  }
+  // add two different dimension for elements:
+  // - all elements with their path information
+  // - only the ids mapped to their rarity
+  let elements = [];
+  let elementCount = 0;
+  let elementIdsForRarity = {};
+  rarityWeights.forEach((rarityWeight) => {
+    let elementsForRarity = getElements(`${dir}/${_id}/${rarityWeight.value}`);
+
+    elementIdsForRarity[rarityWeight.value] = [];
+    elementsForRarity.forEach((_elementForRarity) => {
+      _elementForRarity.id = `${editionDnaPrefix}${elementCount}`;
+      elements.push(_elementForRarity);
+      elementIdsForRarity[rarityWeight.value].push(_elementForRarity.id);
+      elementCount++;
+    })
+    elements[rarityWeight.value] = elementsForRarity;
+  });
+
+  let elementsForLayer = {
+    id: _id,
+    position: _position,
+    size: _size,
+    elements,
+    elementIdsForRarity
+  };
+  return elementsForLayer;
+};
+
+// adds layer-specific percentages to use one vs another rarity
+// @param _rarityId - the id of the rarity to specifiy
+// @param _layerId - the id of the layer to specifiy
+// @param _percentages - an object defining the rarities and the percentage with which a given rarity for this layer should be used
+const addRarityPercentForLayer = (_rarityId, _layerId, _percentages) => {
+  let _rarityFound = false;
+  rarityWeights.forEach((_rarityWeight) => {
+    if (_rarityWeight.value === _rarityId) {
+      let _percentArray = [];
+      for (let percentType in _percentages) {
+        _percentArray.push({
+          id: percentType,
+          percent: _percentages[percentType]
+        })
+      }
+      _rarityWeight.layerPercent[_layerId] = _percentArray;
+      _rarityFound = true;
+    }
+  });
+  if (!_rarityFound) {
+    console.log(`rarity ${_rarityId} not found, failed to add percentage information`);
+  }
+}
+
+/**************************************************************
+ * BEGIN CONFIG
+ *************************************************************/
+
+// image width in pixels
+const width = 1000;
+// image height in pixels
+const height = 1000;
+// description for NFT in metadata file
+const description = "This is an NFT made by the coolest generative code.";
+// base url to use in metadata file
+// the id of the nft will be added to this url, in the example e.g. https://hashlips/nft/1 for NFT with id 1
+const baseImageUri = "https://hashlips/nft";
+// id for edition to start from
+const startEditionFrom = 1;
+// amount of NFTs to generate in edition
+const editionSize = 10;
+// prefix to add to edition dna ids (to distinguish dna counts from different generation processes for the same collection)
+const editionDnaPrefix = 0
+
+// create required weights
+// for each weight, call 'addRarity' with the id and from which to which element this rarity should be applied
+let rarityWeights = [
+  addRarity('super_rare', 1, 1),
+  addRarity('rare', 2, 5),
+  addRarity('original', 5, 10)
 ];
+
+// create required layers
+// for each layer, call 'addLayer' with the id and optionally the positioning and size
+// the id would be the name of the folder in your input directory, e.g. 'ball' for ./input/ball
+const layers = [
+  addLayer('ball'),
+  addLayer('eye color'),
+  addLayer('iris'),
+  addLayer('shine'),
+  addLayer('bottom lid'),
+  addLayer('top lid')
+];
+
+// provide any specific percentages that are required for a given layer and rarity level
+// all provided options are used based on their percentage values to decide which layer to select from
+addRarityPercentForLayer('super_rare', 'ball', { 'super_rare': 33, 'rare': 33, 'original': 33 });
+addRarityPercentForLayer('super_rare', 'eye color', { 'super_rare': 50, 'rare': 25, 'original': 25 });
+addRarityPercentForLayer('original', 'eye color', { 'super_rare': 50, 'rare': 25, 'original': 25 });
 
 module.exports = {
   layers,

--- a/input/config.js
+++ b/input/config.js
@@ -142,7 +142,7 @@ let rarityWeights = [
 // for each layer, call 'addLayer' with the id and optionally the positioning and size
 // the id would be the name of the folder in your input directory, e.g. 'ball' for ./input/ball
 const layers = [
-  addLayer('ball'),
+  addLayer('ball', { x: 0, y: 0 }, { width: width, height: height }),
   addLayer('eye color'),
   addLayer('iris'),
   addLayer('shine'),


### PR DESCRIPTION
... for more expressiveness in NFT combination.
**This change allows to define e.g. the following in the config file:**
`addRarityPercentForLayer('super_rare', 'eye color', { 'super_rare': 50, 'rare': 25, 'original': 25 });`
which would lead to the `eye color` layer on `super_rare` art pieces to have a 50% change of actually being super_rare, and 25% chance to be a rare or original instead.
This should be possible in any combination (allowing originals to contain rare pieces etc.). These changes should also satisfy the requirements that were asked in #11 and #12 .

Also added some more information in the Readme file

Lastly, I cleaned up some function calls in the config file and seperated this into a part of "config helper functions" at top and actual config below, and slimmed down the actual config the user would do. 