### PR TITLE
Add trait type to metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ const getAttributeForElement = (_element) => {
   let attribute = {
     name: selectedElement.name,
     rarity: selectedElement.rarity,
+    trait_type: selectedElement.trait_type
   };
   return attribute;
 };
@@ -97,7 +98,7 @@ const constructLayerToDna = (_dna = [], _layers = [], _rarity) => {
       location: layer.location,
       position: layer.position,
       size: layer.size,
-      selectedElement: {...selectedElement, rarity: _rarity },
+      selectedElement: {...selectedElement, rarity: _rarity, trait_type: layer.id },
     };
   });
   return mappedDnaToLayers;


### PR DESCRIPTION
I was finding it hard to work out which layer was which, so thought it would be good to add the name of each layer to the metadata - as here: 

https://3komsx7x34ttmrex5squrzimwsmkw4lajmw674bfsucnfkxupxoq.arweave.net/2pzJX_ffJzZEl-yhSOUMtJircWBLLe_wJZUE0qr0fd0

