### PR TITLE
Rarity data: Show percentage of each attribute's occurrence in collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,8 @@ Use the existing `addLayers` calls as guidance for how to add layers. This can e
 It is possible to provide a percentage at which e.g. a rare item would contain a rare vs. common part in a given layer. This can be done via the `addRarityPercentForLayer` that can be found in the `config.js` as well. 
 This allows for more fine grained control over how much randomness there should be during the generation process, and allows a combination of common and rare parts.
 
+### Printing rarity data
+To see the percentages of each attribute across your collection, run `node rarityData.js`
+
 # Development suggestions
 - Preferably use VSCode with the prettifier plugin for a consistent coding style (or equivalent js formatting rules)

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ const generateMetadata = (_dna, _edition, _attributesList) => {
 const getAttributeForElement = (_element) => {
   let selectedElement = _element.layer.selectedElement;
   let attribute = {
+    trait_type: _element.layer.name,
     name: selectedElement.name,
     rarity: selectedElement.rarity,
   };
@@ -94,6 +95,7 @@ const constructLayerToDna = (_dna = [], _layers = [], _rarity) => {
   let mappedDnaToLayers = _layers.map((layer, index) => {
     let selectedElement = layer.elements.find(element => element.id === _dna[index]);
     return {
+      name: layer.id,
       location: layer.location,
       position: layer.position,
       size: layer.size,

--- a/rarityData.js
+++ b/rarityData.js
@@ -18,15 +18,13 @@ layers.forEach((layer) => {
 	{
 		elementsList = {
 			value : layer.elements[i].name,
-			occurence : 0,
+			percentage : 0,
 		};
 		rarityForLayer.traits.push(elementsList);
 	}
 
 	rarityChart[layer.id] = rarityForLayer;
 });
-
-console.log(rarityChart)
 
 // read metadata data
 let rawdata = fs.readFileSync('./output/_metadata.json');
@@ -37,21 +35,15 @@ data.forEach((element) => {
 
 	for(let i = 0; i < element.attributes.length; i++)
 	{
-		let traitType = element.attributes[i].name;
-		let value = element.attributes[i].value;
-
-		console.log(element)
-		console.log(element.attributes.length)
-		console.log(element.attributes)
-		console.log(traitType)
-		console.log(rarityChart[traitType])
+		let traitType = element.attributes[i].trait_type;
+		let value = element.attributes[i].name;
 
 		let rarityChartTrait = rarityChart[traitType];
 
 		for (let i = 0; i < rarityChartTrait.traits.length; i++)
 		{
 			if (rarityChartTrait.traits[i].value == value){
-				rarityChartTrait.traits[i].occurence++;
+				rarityChartTrait.traits[i].percentage++;
 			}
 		}
 	}
@@ -62,7 +54,7 @@ data.forEach((element) => {
 for (const [layer, traits] of Object.entries(rarityChart)) {
 	for (const [trait, value] of Object.entries(traits)) {
 		for (const [key, val] of Object.entries(value)) {
-			val.occurence = (val.occurence / NUM_OF_EDITIONS) * 100
+			val.percentage = (val.percentage / editionSize) * 100
 		}
 	}
 }

--- a/rarityData.js
+++ b/rarityData.js
@@ -30,7 +30,7 @@ layers.forEach((layer) => {
 let rawdata = fs.readFileSync('./output/_metadata.json');
 let data = JSON.parse(rawdata);
 
-// fill up rarity chart with occurences from metadata
+// fill up rarity chart with occurrences from metadata
 data.forEach((element) => {
 
 	for(let i = 0; i < element.attributes.length; i++)
@@ -50,7 +50,7 @@ data.forEach((element) => {
 
 });
 
-// iterate through rarity list and convert the occurences to percentages
+// iterate through rarity list and convert the occurrences to percentages
 for (const [layer, traits] of Object.entries(rarityChart)) {
 	for (const [trait, value] of Object.entries(traits)) {
 		for (const [key, val] of Object.entries(value)) {

--- a/rarityData.js
+++ b/rarityData.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const fs = require('fs');
+const {
+  layers,
+  editionSize
+} = require("./input/config.js");
+
+let rarityChart = [];
+
+// initialize rarity chart
+layers.forEach((layer) => {
+	let elementsList = [];
+	let rarityForLayer = {
+		traits: elementsList
+	};
+	for(let i = 0; i < layer.elements.length; i++)
+	{
+		elementsList = {
+			value : layer.elements[i].name,
+			occurence : 0,
+		};
+		rarityForLayer.traits.push(elementsList);
+	}
+
+	rarityChart[layer.id] = rarityForLayer;
+});
+
+console.log(rarityChart)
+
+// read metadata data
+let rawdata = fs.readFileSync('./output/_metadata.json');
+let data = JSON.parse(rawdata);
+
+// fill up rarity chart with occurences from metadata
+data.forEach((element) => {
+
+	for(let i = 0; i < element.attributes.length; i++)
+	{
+		let traitType = element.attributes[i].name;
+		let value = element.attributes[i].value;
+
+		console.log(element)
+		console.log(element.attributes.length)
+		console.log(element.attributes)
+		console.log(traitType)
+		console.log(rarityChart[traitType])
+
+		let rarityChartTrait = rarityChart[traitType];
+
+		for (let i = 0; i < rarityChartTrait.traits.length; i++)
+		{
+			if (rarityChartTrait.traits[i].value == value){
+				rarityChartTrait.traits[i].occurence++;
+			}
+		}
+	}
+
+});
+
+// iterate through rarity list and convert the occurences to percentages
+for (const [layer, traits] of Object.entries(rarityChart)) {
+	for (const [trait, value] of Object.entries(traits)) {
+		for (const [key, val] of Object.entries(value)) {
+			val.occurence = (val.occurence / NUM_OF_EDITIONS) * 100
+		}
+	}
+}
+
+// print out rarity data to console
+for (const [layer, traits] of Object.entries(rarityChart)) {
+	console.log(`Layer: ${layer}`)
+	for (const [trait, value] of Object.entries(traits)) {
+		console.log(value)
+	}
+}


### PR DESCRIPTION
This pull request adds a rarityData.js file that prints out the percentages of each attribute's occurrence throughout the collection. I added the layer name (calling it trait_type) to the metadata to make things easier. This seems to be typical of candy machines like metaplex anyway.